### PR TITLE
Direct summary output to stderr for JSON formatting

### DIFF
--- a/list_ansible_module_usages.py
+++ b/list_ansible_module_usages.py
@@ -242,13 +242,13 @@ def output_json(files, fqcn_map):
                 "role": role
             })
     print(json.dumps(data, indent=2))
-    print(f"\nTotal unique modules: {len(unique_modules)}")
-    print("\nModule summary by role:")
+    print(f"\nTotal unique modules: {len(unique_modules)}", file=sys.stderr)
+    print("\nModule summary by role:", file=sys.stderr)
     for role in sorted(role_to_modules):
         rolename = role if role else "Not in role"
-        print(f"Role: {rolename}")
+        print(f"Role: {rolename}", file=sys.stderr)
         for mod in sorted(role_to_modules[role]):
-            print(f"  {mod}")
+            print(f"  {mod}", file=sys.stderr)
 
 def output_csv(files, fqcn_map):
     import csv


### PR DESCRIPTION
## Summary
- Ensure JSON mode writes only data to stdout
- Send module summary details to stderr

## Testing
- `pip install pyyaml` *(failed: Tunnel connection failed: 403 Forbidden)*
- `python -m py_compile list_ansible_module_usages.py`
- `python - <<'PY'` (capture JSON stdout and summary stderr)


------
https://chatgpt.com/codex/tasks/task_e_68a849b42eb08322b4bd977c2812f6d2